### PR TITLE
Switch from open to URI.open

### DIFF
--- a/lib/terraform/binary/executable.rb
+++ b/lib/terraform/binary/executable.rb
@@ -38,8 +38,7 @@ module Terraform
         require 'open-uri'
 
         File.open("#{@download_path}/#{@download_filename}", 'wb') do |saved_file|
-          # the following "open" is provided by open-uri
-          open("https://#{download_domain}/#{download_uri}", 'rb') do |read_file|
+          URI.open("https://#{download_domain}/#{download_uri}", 'rb') do |read_file|
             saved_file.write(read_file.read)
           end
         end

--- a/lib/terraform/binary/version.rb
+++ b/lib/terraform/binary/version.rb
@@ -1,7 +1,7 @@
 module Terraform
   module Binary
     # Gem Version
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.1'.freeze
 
     # The version number of the Terraform binary to download and use
     TERRAFORM_VERSION = '1.1.2'.freeze


### PR DESCRIPTION
- Breaking change in Ruby 2.7 means open no longer works in any supported ruby version (https://rubyreferences.github.io/rubychanges/2.7.html#network-and-web)
- URI.open is available since Ruby 2.5 (https://rubyreferences.github.io/rubychanges/2.5.html#network-and-web)
- Ruby Discussion: https://bugs.ruby-lang.org/issues/15893